### PR TITLE
fix: handle duplicate dynamic rule IDs during cookie rule registration

### DIFF
--- a/exia-invasion/src/services/requestInterceptor.js
+++ b/exia-invasion/src/services/requestInterceptor.js
@@ -55,8 +55,13 @@ export const registerCookieRules = async (accounts) => {
   if (rules.length === 0) return;
   
   try {
+    // 防御性移除同 ID 规则，避免并发/异常中断后再次注册时报 "id 不唯一"
+    const existingRules = await chrome.declarativeNetRequest.getDynamicRules();
+    const existingRuleIds = existingRules.map(rule => rule.id);
+    const removeRuleIds = [...new Set([...existingRuleIds, ...newRuleIds])];
+
     await chrome.declarativeNetRequest.updateDynamicRules({
-      removeRuleIds: [],
+      removeRuleIds,
       addRules: rules
     });
     registeredRuleIds = newRuleIds;


### PR DESCRIPTION
### Motivation
- Concurrent or interrupted runs could leave stale dynamic rules and cause `declarativeNetRequest.updateDynamicRules` to fail with duplicate-ID errors when `registerCookieRules` reuses IDs starting from `10000`.
- The failing point is the cookie-isolation rule registration used during account validation and after re-login (`registerCookieRules` is called in multiple phases). 

### Description
- Added defensive removal logic in `registerCookieRules` to call `chrome.declarativeNetRequest.getDynamicRules()` and compute a `removeRuleIds` set that includes existing dynamic rule IDs and the new IDs to be registered before calling `updateDynamicRules`.
- This makes rule registration idempotent and avoids the `id not unique` error when stale rules remain; the change is in `exia-invasion/src/services/requestInterceptor.js` and preserves existing behavior of `unregisterAllRules`.

### Testing
- Ran automated linting with `npm run lint` in `exia-invasion/` and it passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c5da745d488323b7a78e167f93f914)