### PR TITLE
修改cookie有效性的判定逻辑。

### DIFF
--- a/exia-invasion/src/components/app/hooks/useCrawler.js
+++ b/exia-invasion/src/components/app/hooks/useCrawler.js
@@ -14,6 +14,84 @@ import { parseGameUidFromCookie, cookieArrToStr } from "../utils.js";
 import { BATCH_SIZE, STAGGER_DELAY } from "../constants.js";
 
 const AUTO_SAVE_DATA = true;
+const REQUIRED_LOGIN_COOKIE_NAMES = ["game_token", "game_uid", "game_openid"];
+
+const emitCrawlerDiagnostic = (onDiagnostic, message) => {
+  if (typeof onDiagnostic !== "function") return;
+  try {
+    onDiagnostic(message);
+  } catch {
+    // 诊断日志不能影响登录流程
+  }
+};
+
+const maskDiagnosticText = (value) => {
+  const text = String(value || "").trim();
+  if (!text) return "";
+  if (text.length <= 2) return `${text.slice(0, 1)}*`;
+  return `${text.slice(0, 2)}***${text.slice(-2)}`;
+};
+
+const getAccountDiagnosticLabel = (account) => {
+  const gameUid = String(account?.game_uid || account?.gameUid || "").trim();
+  if (gameUid) return `uid:***${gameUid.slice(-4)}`;
+
+  const email = String(account?.email || "").trim();
+  if (email) {
+    const [localPart, domain] = email.split("@");
+    return `email:${localPart?.slice(0, 1) || "*"}***${domain ? `@${domain}` : ""}`;
+  }
+
+  const displayName = account?.username || account?.name;
+  return displayName ? `name:${maskDiagnosticText(displayName)}` : "unknown-account";
+};
+
+const sanitizeCookieName = (name) => {
+  const text = String(name || "");
+  if (/^__ss_storage_cookie_cache_/.test(text)) return "__ss_storage_cookie_cache_*";
+  return text.length > 48 ? `${text.slice(0, 40)}…` : text;
+};
+
+const summarizeBrowserCookies = (cookies) => {
+  const relevantCookies = (cookies || []).filter((cookie) =>
+    String(cookie?.domain || "").endsWith("blablalink.com")
+  );
+  const requiredSummary = REQUIRED_LOGIN_COOKIE_NAMES.map((name) => {
+    const matches = relevantCookies.filter((cookie) => cookie.name === name);
+    if (matches.length === 0) return `${name}=missing`;
+    const metadata = matches
+      .map((cookie) => `${cookie.domain}${cookie.path};sameSite=${cookie.sameSite || "unspecified"}`)
+      .join("|");
+    return `${name}=present(${metadata})`;
+  });
+  const cookieNames = [...new Set(relevantCookies.map((cookie) => sanitizeCookieName(cookie.name)))]
+    .sort();
+
+  return `Cookie快照: total=${relevantCookies.length}; ${requiredSummary.join("; ")}; names=[${cookieNames.join(",")}]`;
+};
+
+const createAccountDiagnosticLogger = (addLog, account, scope) => {
+  const accountLabel = getAccountDiagnosticLabel(account);
+  return (message) => {
+    const timestamp = new Date().toISOString().slice(11, 23);
+    const line = `[诊断 ${timestamp}][${accountLabel}][${scope}] ${message}`;
+    console.debug(line);
+    addLog(line);
+  };
+};
+
+const getDistinctBatchAreaIds = (accounts) => {
+  return [...new Set(
+    (accounts || [])
+      .map((account) => String(account?.roleInfo?.area_id || "").trim())
+      .filter(Boolean)
+  )];
+};
+
+const getSharedBatchAreaId = (accounts) => {
+  const areaIds = getDistinctBatchAreaIds(accounts);
+  return areaIds.length === 1 ? areaIds[0] : "";
+};
 
 /**
  * 数据爬取 Hook
@@ -107,11 +185,12 @@ export function useCrawler({ t, lang, saveAsZip, exportJson, activateTab, server
   }, [t, addLog]);
 
   // ========== 登录并获取 Cookie ==========
-  const loginAndGetCookie = useCallback(async (acc, serverFlag) => {
+  const loginAndGetCookie = useCallback(async (acc, serverFlag, onDiagnostic) => {
     const LOGIN_COOKIE_TIMEOUT_MS = 20000;
     const LOGIN_COOKIE_MAX_ATTEMPTS = 2;
+    const loginStartedAt = Date.now();
 
-    const waitForCookie = () => new Promise((resolve, reject) => {
+    const waitForCookie = (attemptStartedAt) => new Promise((resolve, reject) => {
       const onChanged = (chg) => {
         const c = chg.cookie;
         if (
@@ -120,7 +199,17 @@ export function useCrawler({ t, lang, saveAsZip, exportJson, activateTab, server
           c.name === "game_token"
         ) {
           cleanup();
-          resolve();
+          const event = {
+            domain: c.domain,
+            path: c.path,
+            sameSite: c.sameSite || "unspecified",
+            elapsedMs: Date.now() - attemptStartedAt,
+          };
+          emitCrawlerDiagnostic(
+            onDiagnostic,
+            `检测到 game_token 写入事件: domain=${event.domain}; path=${event.path}; sameSite=${event.sameSite}; attemptElapsed=${event.elapsedMs}ms`
+          );
+          resolve(event);
         }
       };
       const cleanup = () => {
@@ -129,12 +218,21 @@ export function useCrawler({ t, lang, saveAsZip, exportJson, activateTab, server
       };
       const timeoutId = setTimeout(() => {
         cleanup();
+        emitCrawlerDiagnostic(
+          onDiagnostic,
+          `等待 game_token 超时: timeout=${LOGIN_COOKIE_TIMEOUT_MS}ms`
+        );
         reject(new Error("COOKIE_TIMEOUT"));
       }, LOGIN_COOKIE_TIMEOUT_MS);
       chrome.cookies.onChanged.addListener(onChanged);
     });
 
     for (let attempt = 1; attempt <= LOGIN_COOKIE_MAX_ATTEMPTS; attempt += 1) {
+      const attemptStartedAt = Date.now();
+      emitCrawlerDiagnostic(
+        onDiagnostic,
+        `登录尝试开始: attempt=${attempt}/${LOGIN_COOKIE_MAX_ATTEMPTS}; server=${serverFlag}; activateTab=${activateTab}`
+      );
       addLog(t("getCookie"));
       let tab;
       try {
@@ -142,6 +240,7 @@ export function useCrawler({ t, lang, saveAsZip, exportJson, activateTab, server
           url: "https://www.blablalink.com/login",
           active: activateTab,
         });
+        emitCrawlerDiagnostic(onDiagnostic, `登录标签页已创建: tabId=${tab.id}`);
         
         await new Promise((resolve) => {
           const listener = (id, info) => {
@@ -152,6 +251,10 @@ export function useCrawler({ t, lang, saveAsZip, exportJson, activateTab, server
           };
           chrome.tabs.onUpdated.addListener(listener);
         });
+        emitCrawlerDiagnostic(
+          onDiagnostic,
+          `登录页加载完成: attemptElapsed=${Date.now() - attemptStartedAt}ms`
+        );
         
         await chrome.scripting.executeScript({
           target: { tabId: tab.id },
@@ -219,12 +322,28 @@ export function useCrawler({ t, lang, saveAsZip, exportJson, activateTab, server
           },
           args: [{ email: acc.email, password: acc.password, server: serverFlag }],
         });
+        emitCrawlerDiagnostic(
+          onDiagnostic,
+          `登录脚本已注入，等待 game_token: attemptElapsed=${Date.now() - attemptStartedAt}ms`
+        );
         
-        await waitForCookie();
+        const tokenEvent = await waitForCookie(attemptStartedAt);
         if (tab?.id) chrome.tabs.remove(tab.id);
-        return;
+        emitCrawlerDiagnostic(
+          onDiagnostic,
+          `loginAndGetCookie 返回: attempt=${attempt}; totalElapsed=${Date.now() - loginStartedAt}ms`
+        );
+        return {
+          attempt,
+          tokenEvent,
+          totalElapsedMs: Date.now() - loginStartedAt,
+        };
       } catch (err) {
         if (tab?.id) chrome.tabs.remove(tab.id);
+        emitCrawlerDiagnostic(
+          onDiagnostic,
+          `登录尝试异常: attempt=${attempt}; error=${err?.message || err}; attemptElapsed=${Date.now() - attemptStartedAt}ms`
+        );
         if (attempt < LOGIN_COOKIE_MAX_ATTEMPTS) {
           addLog(`登录超时，重试 ${attempt + 1}/${LOGIN_COOKIE_MAX_ATTEMPTS}`);
           continue;
@@ -386,15 +505,18 @@ export function useCrawler({ t, lang, saveAsZip, exportJson, activateTab, server
       const excelMime = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
       
       // ========== 阶段1: 账号验证 ==========
-      const validAccounts = [];
-      const invalidAccounts = [];
-      const noCredAccounts = [];
+      const authenticatedAccounts = [];
+      const reloginAccounts = [];
+      const unavailableAccounts = [];
 
       if (!onlyCookie) {
         addLog(`----------------------------`);
         addLog(`[阶段1] 并发验证 Cookie...`);
         
         // 注册拦截规则
+        addLog(
+          `[诊断] Cookie注入规则准备: accounts=${accounts.length}; eligible=${accounts.filter((account) => account.game_uid && account.cookie).length}; missingGameUid=${accounts.filter((account) => !account.game_uid).length}; missingCookie=${accounts.filter((account) => !account.cookie).length}`
+        );
         await registerCookieRules(accounts);
         
         // 分批并发验证
@@ -405,7 +527,8 @@ export function useCrawler({ t, lang, saveAsZip, exportJson, activateTab, server
             const delay = idx * STAGGER_DELAY;
             return (async () => {
               await new Promise(r => setTimeout(r, delay));
-              const result = await validateCookieWithAccount(acc);
+              const diagnosticLog = createAccountDiagnosticLogger(addLog, acc, "保存Cookie验证");
+              const result = await validateCookieWithAccount(acc, diagnosticLog);
               return { acc, result };
             })();
           });
@@ -414,67 +537,139 @@ export function useCrawler({ t, lang, saveAsZip, exportJson, activateTab, server
           
           for (const { acc, result } of batchResults) {
             if (result.valid) {
-              validAccounts.push({ ...acc, roleInfo: result.roleInfo });
-              addLog(`✓ ${acc.username || acc.name || t("noName")} - Cookie 有效`);
+              authenticatedAccounts.push({
+                ...acc,
+                roleInfo: {
+                  role_name: result.roleInfo?.role_name || acc.username || acc.name || "",
+                  area_id: result.roleInfo?.area_id || "",
+                },
+              });
+              if (result.roleReady) {
+                addLog(`✓ ${acc.username || acc.name || t("noName")} - Cookie 有效`);
+              } else {
+                addLog(`✓ ${acc.username || acc.name || t("noName")} - Cookie 有效，area_id 待批次回填`);
+              }
             } else {
               if (acc.password) {
-                invalidAccounts.push(acc);
+                reloginAccounts.push(acc);
                 addLog(`✗ ${acc.username || acc.name || t("noName")} - Cookie 失效，待重登`);
               } else {
-                noCredAccounts.push({ acc, reason: result.error || "Cookie 失效且无密码" });
+                unavailableAccounts.push({ acc, reason: result.error || "Cookie 失效且无密码" });
                 addLog(`✗ ${acc.username || acc.name || t("noName")} - ${result.error || "Cookie 失效"}，无密码跳过`);
               }
             }
           }
         }
-        
-        addLog(`验证完成: ${validAccounts.length} 有效, ${invalidAccounts.length} 待重登, ${noCredAccounts.length} 无法处理`);
+
+        const pendingAreaCount = authenticatedAccounts.filter(
+          (account) => !account.roleInfo?.area_id
+        ).length;
+        addLog(
+          `验证完成: ${authenticatedAccounts.length} 登录态有效 (${pendingAreaCount} 待回填 area_id), ${reloginAccounts.length} 待重登, ${unavailableAccounts.length} 无法处理`
+        );
       } else {
         // 仅更新 Cookie：跳过验证，直接按启用开关强制重登更新
         accounts.forEach((acc) => {
           if (acc.password) {
-            invalidAccounts.push(acc);
+            reloginAccounts.push(acc);
           } else {
-            noCredAccounts.push({ acc, reason: "无密码，无法更新 Cookie" });
+            unavailableAccounts.push({ acc, reason: "无密码，无法更新 Cookie" });
             addLog(`✗ ${acc.username || acc.name || t("noName")} - 无密码跳过`);
           }
         });
       }
       
       // ========== 阶段2: 串行重新登录失效账号 ==========
-      if (invalidAccounts.length > 0) {
+      if (reloginAccounts.length > 0) {
         addLog(`----------------------------`);
-        addLog(onlyCookie ? `串行更新 ${invalidAccounts.length} 个账号 Cookie...` : `[阶段2] 串行重新登录 ${invalidAccounts.length} 个账号...`);
+        addLog(onlyCookie ? `串行更新 ${reloginAccounts.length} 个账号 Cookie...` : `[阶段2] 串行重新登录 ${reloginAccounts.length} 个账号...`);
         
-        for (const acc of invalidAccounts) {
+        for (const acc of reloginAccounts) {
           addLog(`正在登录: ${acc.username || acc.name || acc.email || t("noName")}`);
+          const diagnosticLog = createAccountDiagnosticLogger(addLog, acc, "重新登录");
+          diagnosticLog(
+            `开始: server=${server}; storedCookie=${acc.cookie ? "present" : "empty"}; storedGameUid=${acc.game_uid ? "present" : "empty"}`
+          );
           
           try {
             // 清除浏览器 Cookie 并执行登录
             await clearSiteCookies();
-            await loginAndGetCookie(acc, server);
+            diagnosticLog("BlaBlaLink Cookie 清理完成");
+            const loginResult = await loginAndGetCookie(acc, server, diagnosticLog);
+            diagnosticLog(
+              `登录函数完成: attempt=${loginResult?.attempt ?? "unknown"}; totalElapsed=${loginResult?.totalElapsedMs ?? "unknown"}ms`
+            );
             
             // 获取新 Cookie
             const cks = (await chrome.cookies.getAll({}))
               .filter(c => c.domain.endsWith("blablalink.com"));
+            diagnosticLog(summarizeBrowserCookies(cks));
             const newCookieStr = cookieArrToStr(cks);
+            const gameTokenCookie = cks.find(c => c.name === "game_token");
+            if (!newCookieStr || !gameTokenCookie) {
+              throw new Error("登录后未取得 game_token Cookie");
+            }
+
             acc.cookie = newCookieStr;
             acc.cookieUpdatedAt = Date.now();
             const gameUidCookie = cks.find(c => c.name === "game_uid");
             if (gameUidCookie) acc.game_uid = gameUidCookie.value;
-            
-            // 验证新 Cookie
-            await applyCookieStr(newCookieStr);
-            const roleInfo = await getRoleName();
-            
-            if (roleInfo.area_id) {
-              validAccounts.push({ ...acc, roleInfo });
+            diagnosticLog(
+              `Cookie收集完成: serializedCookie=${newCookieStr ? "present" : "empty"}; serializedCookieCount=${newCookieStr ? newCookieStr.split(/;\s*/).filter(Boolean).length : 0}; game_uid写回=${gameUidCookie ? "yes" : "no"}`
+            );
+
+            let roleInfo = {
+              role_name: acc.username || acc.name || "",
+              area_id: "",
+            };
+            let areaSource = "pending";
+
+            if (onlyCookie) {
+              diagnosticLog("已取得 game_token，按 Cookie 更新模式判定重登成功，跳过 area_id 验证");
+            } else {
+              const existingBatchAreaId = getSharedBatchAreaId(authenticatedAccounts);
+              if (existingBatchAreaId) {
+                roleInfo.area_id = existingBatchAreaId;
+                areaSource = "batch";
+                diagnosticLog("已取得 game_token，直接采用本批次已确认的 area_id");
+              } else {
+                await applyCookieStr(newCookieStr);
+                diagnosticLog("Cookie 重新应用完成；本批次尚无 area_id，尝试从当前账号发现");
+                try {
+                  const discoveredRoleInfo = await getRoleName(diagnosticLog);
+                  roleInfo = {
+                    role_name: discoveredRoleInfo.role_name || roleInfo.role_name,
+                    area_id: discoveredRoleInfo.area_id || "",
+                  };
+                  areaSource = roleInfo.area_id ? "account" : "pending";
+                  diagnosticLog(
+                    `玩家信息探测结果: area_id=${roleInfo.area_id ? "present" : "empty"}; role_name=${roleInfo.role_name ? "present" : "empty"}`
+                  );
+                } catch (error) {
+                  diagnosticLog(
+                    `玩家信息探测异常但不影响重登成功: ${error?.message || error}`
+                  );
+                }
+              }
+            }
+
+            authenticatedAccounts.push({ ...acc, roleInfo });
+
+            if (onlyCookie) {
+              addLog(`✓ ${acc.username || acc.name || t("noName")} - Cookie 更新成功`);
+            } else if (areaSource === "batch") {
+              addLog(`✓ ${acc.username || roleInfo.role_name || t("noName")} - 登录成功，已使用批次 area_id`);
+            } else if (roleInfo.area_id) {
               addLog(`✓ ${acc.username || roleInfo.role_name || t("noName")} - 登录成功`);
-              
-              // 回写账号信息
-              if (AUTO_SAVE_DATA) {
-                if (roleInfo.role_name) acc.username = roleInfo.role_name;
-                
+            } else {
+              addLog(`✓ ${acc.username || acc.name || t("noName")} - 登录成功，area_id 待批次回填`);
+            }
+
+            // Cookie 获取成功后立即回写账号，不再依赖 area_id。
+            if (AUTO_SAVE_DATA) {
+              if (roleInfo.role_name) acc.username = roleInfo.role_name;
+
+              try {
                 const all = await getAccounts();
                 const now = Date.now();
                 let existingIndex = -1;
@@ -503,29 +698,73 @@ export function useCrawler({ t, lang, saveAsZip, exportJson, activateTab, server
                   });
                 }
                 await setAccounts(all);
+                diagnosticLog("新 Cookie 已回写账号存储");
+              } catch (error) {
+                diagnosticLog(
+                  `新 Cookie 回写账号存储失败，但当前重登结果仍有效: ${error?.message || error}`
+                );
               }
-            } else {
-              noCredAccounts.push({ acc, reason: "登录后 area_id 为空" });
-              addLog(`✗ ${acc.username || acc.name || t("noName")} - 登录后验证失败`);
             }
           } catch (err) {
-            noCredAccounts.push({ acc, reason: `登录失败: ${err.message}` });
+            unavailableAccounts.push({ acc, reason: `登录失败: ${err.message}` });
+            diagnosticLog(`异常归类: ${err?.message || err}`);
             addLog(`✗ ${acc.username || acc.name || t("noName")} - ${err.message}`);
           }
         }
-        
-        // 更新拦截规则
-        await registerCookieRules(validAccounts);
       }
 
       if (onlyCookie) {
         addLog(`----------------------------`);
+        addLog(
+          `Cookie 更新结果: ${authenticatedAccounts.length} 成功, ${unavailableAccounts.length} 失败`
+        );
         addLog(t("cookieOnlyDone"));
         
         return;
       }
-      
-      if (validAccounts.length === 0) {
+
+      // 同一业务批次共享 area_id：仅在本批次实际观测到唯一值时回填。
+      const batchAreaIds = getDistinctBatchAreaIds(authenticatedAccounts);
+      const sharedBatchAreaId = batchAreaIds.length === 1 ? batchAreaIds[0] : "";
+      const pendingAreaAccounts = authenticatedAccounts.filter(
+        (account) => !account.roleInfo?.area_id
+      );
+
+      let crawlableAccounts = authenticatedAccounts.filter(
+        (account) => Boolean(account.roleInfo?.area_id)
+      );
+
+      if (sharedBatchAreaId) {
+        crawlableAccounts = authenticatedAccounts.map((account) => ({
+          ...account,
+          roleInfo: {
+            ...account.roleInfo,
+            role_name:
+              account.roleInfo?.role_name || account.username || account.name || "",
+            area_id: account.roleInfo?.area_id || sharedBatchAreaId,
+          },
+        }));
+        addLog(
+          `批次 area_id 已确认：${pendingAreaAccounts.length} 个账号完成共享回填，${crawlableAccounts.length} 个账号可爬取`
+        );
+      } else if (pendingAreaAccounts.length > 0) {
+        const reason = batchAreaIds.length > 1
+          ? "同批次检测到多个 area_id，无法安全回填"
+          : "登录成功，但本批次未取得可共享的 area_id";
+        pendingAreaAccounts.forEach((acc) => {
+          unavailableAccounts.push({ acc, reason });
+        });
+        addLog(
+          batchAreaIds.length > 1
+            ? `⚠ 同批次检测到 ${batchAreaIds.length} 个不同的 area_id，未对 ${pendingAreaAccounts.length} 个账号执行回填`
+            : `✗ 本批次所有已登录账号均未取得 area_id，暂时无法开始角色数据爬取`
+        );
+      }
+
+      // 只为最终可爬取账号注册 Cookie 隔离规则。
+      await registerCookieRules(crawlableAccounts);
+
+      if (crawlableAccounts.length === 0) {
         addLog(`----------------------------`);
         addLog(`没有可用账号，流程结束`);
         return;
@@ -533,10 +772,10 @@ export function useCrawler({ t, lang, saveAsZip, exportJson, activateTab, server
       
       // ========== 阶段3: 并发爬取数据 ==========
       addLog(`----------------------------`);
-      addLog(`[阶段3] 并发爬取 ${validAccounts.length} 个账号数据...`);
+      addLog(`[阶段3] 并发爬取 ${crawlableAccounts.length} 个账号数据...`);
       
       const successAccounts = [];
-      const failedAccounts = [...noCredAccounts.map(({ acc, reason }) => ({ name: acc.username || acc.name || t("noName"), reason }))];
+      const failedAccounts = [...unavailableAccounts.map(({ acc, reason }) => ({ name: acc.username || acc.name || t("noName"), reason }))];
       
       // 单个账号的数据爬取函数
       const crawlAccountData = async (acc) => {
@@ -545,7 +784,7 @@ export function useCrawler({ t, lang, saveAsZip, exportJson, activateTab, server
         try {
           // 构建数据字典
           const dict = await loadBaseAccountDict();
-          dict.name = acc.roleInfo.role_name;
+          dict.name = acc.roleInfo.role_name || acc.username || acc.name || "";
           dict.area_id = acc.roleInfo.area_id;
           dict.cookie = acc.cookie || "";
           
@@ -579,8 +818,8 @@ export function useCrawler({ t, lang, saveAsZip, exportJson, activateTab, server
       };
       
       // 分批并发爬取
-      for (let batchStart = 0; batchStart < validAccounts.length; batchStart += BATCH_SIZE) {
-        const batch = validAccounts.slice(batchStart, batchStart + BATCH_SIZE);
+      for (let batchStart = 0; batchStart < crawlableAccounts.length; batchStart += BATCH_SIZE) {
+        const batch = crawlableAccounts.slice(batchStart, batchStart + BATCH_SIZE);
         
         const batchPromises = batch.map((acc, idx) => {
           const delay = idx * STAGGER_DELAY;

--- a/exia-invasion/src/services/api.js
+++ b/exia-invasion/src/services/api.js
@@ -63,15 +63,111 @@ const buildHeader = () => ({
   Accept: "application/json",
 });
 
-const postJson = async (url, bodyObj) => {
-  const res = await fetch(url, {
-    method: "POST",
-    headers: buildHeader(),
-    body: JSON.stringify(bodyObj),
-    credentials: "include", // 自动携带Cookie
-  });
+const emitDiagnostic = (onDiagnostic, message) => {
+  if (typeof onDiagnostic !== "function") return;
+  try {
+    onDiagnostic(message);
+  } catch {
+    // 诊断日志不能影响请求和验证结果
+  }
+};
+
+const getEndpointName = (url) => {
+  const path = String(url || "").split("?")[0];
+  return path.split("/").filter(Boolean).pop() || "unknown-endpoint";
+};
+
+const sanitizeDiagnosticText = (value, maxLength = 160) => {
+  const text = String(value ?? "")
+    .replace(/\s+/g, " ")
+    .replace(/((?:token|cookie|password|authorization)\s*[:=]\s*)[^\s,;]+/gi, "$1[REDACTED]")
+    .trim();
+  return text.length > maxLength ? `${text.slice(0, maxLength)}…` : text;
+};
+
+const describeDiagnosticValue = (value) => {
+  if (value === undefined) return "missing";
+  if (value === null) return "null";
+  if (value === "") return "empty-string";
+  if (typeof value === "string") return `string(${sanitizeDiagnosticText(value, 40)})`;
+  if (typeof value === "number") return `number(${value})`;
+  if (typeof value === "boolean") return `boolean(${value})`;
+  if (Array.isArray(value)) return `array(length=${value.length})`;
+  if (typeof value === "object") return "object";
+  return typeof value;
+};
+
+const summarizeApiResponse = (payload) => {
+  if (!payload || typeof payload !== "object") {
+    return `payload=${describeDiagnosticValue(payload)}`;
+  }
+
+  const businessCode = payload.code ?? payload.retcode ?? payload.ret_code ?? "missing";
+  const businessMessage = payload.message ?? payload.msg ?? payload.error?.message ?? "";
+  const data = payload.data;
+  const dataKeys = data && typeof data === "object" && !Array.isArray(data)
+    ? Object.keys(data).slice(0, 20)
+    : [];
+  const areaId = data && typeof data === "object" ? data.area_id : undefined;
+
+  return [
+    `businessCode=${sanitizeDiagnosticText(businessCode, 40) || "empty"}`,
+    `businessMessage=${businessMessage ? sanitizeDiagnosticText(businessMessage) : "empty"}`,
+    `data=${describeDiagnosticValue(data)}`,
+    `dataKeys=[${dataKeys.join(",")}]`,
+    `area_id=${describeDiagnosticValue(areaId)}`,
+  ].join("; ");
+};
+
+const requestJson = async (url, options, onDiagnostic) => {
+  const endpoint = getEndpointName(url);
+  const startedAt = Date.now();
+  emitDiagnostic(onDiagnostic, `${endpoint} 请求开始`);
+
+  let res;
+  try {
+    res = await fetch(url, options);
+  } catch (error) {
+    emitDiagnostic(
+      onDiagnostic,
+      `${endpoint} 网络异常: ${sanitizeDiagnosticText(error?.message || error)}; elapsed=${Date.now() - startedAt}ms`
+    );
+    throw error;
+  }
+
+  emitDiagnostic(
+    onDiagnostic,
+    `${endpoint} HTTP响应: status=${res.status}; ok=${res.ok}; statusText=${sanitizeDiagnosticText(res.statusText) || "empty"}; elapsed=${Date.now() - startedAt}ms`
+  );
+
   if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-  return res.json();
+
+  let payload;
+  try {
+    payload = await res.json();
+  } catch (error) {
+    emitDiagnostic(
+      onDiagnostic,
+      `${endpoint} JSON解析失败: ${sanitizeDiagnosticText(error?.message || error)}`
+    );
+    throw error;
+  }
+
+  emitDiagnostic(onDiagnostic, `${endpoint} 响应摘要: ${summarizeApiResponse(payload)}`);
+  return payload;
+};
+
+const postJson = (url, bodyObj, onDiagnostic) => {
+  return requestJson(
+    url,
+    {
+      method: "POST",
+      headers: buildHeader(),
+      body: JSON.stringify(bodyObj),
+      credentials: "include", // 自动携带Cookie
+    },
+    onDiagnostic
+  );
 };
 
 /**
@@ -82,22 +178,25 @@ const postJson = async (url, bodyObj) => {
  * @param {string} accountId - 账号 game_uid
  * @returns {Promise<object>} - 响应 JSON
  */
-const postJsonWithAccount = async (url, bodyObj, accountId) => {
+const postJsonWithAccount = async (url, bodyObj, accountId, onDiagnostic) => {
   if (!accountId) {
+    emitDiagnostic(onDiagnostic, `${getEndpointName(url)} 请求前检查失败: 缺少 game_uid`);
     throw new Error("缺少 game_uid，无法并发请求");
   }
   // 在 URL 后附加账号标识参数
   const separator = url.includes("?") ? "&" : "?";
   const urlWithId = `${url}${separator}_acct_id=${accountId}`;
   
-  const res = await fetch(urlWithId, {
-    method: "POST",
-    headers: buildHeader(),
-    body: JSON.stringify(bodyObj),
-    credentials: "omit", // 不携带浏览器 Cookie，由拦截器注入
-  });
-  if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
-  return res.json();
+  return requestJson(
+    urlWithId,
+    {
+      method: "POST",
+      headers: buildHeader(),
+      body: JSON.stringify(bodyObj),
+      credentials: "omit", // 不携带浏览器 Cookie，由拦截器注入
+    },
+    onDiagnostic
+  );
 };
 
 /* ========== 游戏API接口 ========== */
@@ -115,37 +214,388 @@ const getIntlOpenId = async () => {
   throw new Error("未找到 game_openid cookie");
 };
 
-// 获取最新昵称（优先 BasicInfo.nickname，回退旧 role_name）；不因空昵称判定 Cookie 失效
-export const getRoleName = async () => {
-  const oldPromise = postJson(
-    "https://api.blablalink.com/api/ugc/direct/standalonesite/User/GetUserGamePlayerInfo",
-    {}
-  ).catch(err => ({ error: err }));
+const USER_GAME_PLAYER_INFO_URL =
+  "https://api.blablalink.com/api/ugc/direct/standalonesite/User/GetUserGamePlayerInfo";
+const USER_CHECK_LOGIN_URL =
+  "https://api.blablalink.com/api/user/CheckLogin";
+const USER_INFO_NEW_URL =
+  "https://api.blablalink.com/api/ugc/proxy/standalonesite/User/GetUserInfoNew";
+const USER_PRIVACY_SETTING_URL =
+  "https://api.blablalink.com/api/ugc/direct/standalonesite/User/GetUserPrivacySetting";
+const PLAYER_INFO_SYSTEM_ERROR_CODE = "1300015";
+const PLAYER_INFO_RETRY_DELAYS_MS = [1000, 2000];
 
-  const oldResp = await oldPromise;
+const getApiBusinessCode = (response) => {
+  return response?.code ?? response?.retcode ?? response?.ret_code;
+};
+
+const isApiResponseSuccessful = (response) => {
+  return String(getApiBusinessCode(response)) === "0";
+};
+
+const isPlayerInfoResponseSuccessful = (response) => {
+  return isApiResponseSuccessful(response) && Boolean(response?.data?.area_id);
+};
+
+const getCanonicalIntlOpenId = (response) => {
+  return String(
+    response?.data?.info?.intl_openid ??
+    response?.data?.intl_openid ??
+    ""
+  ).trim();
+};
+
+const summarizeIntlOpenIdRelation = (canonicalIntlOpenId, gameOpenId) => {
+  const canonicalText = String(canonicalIntlOpenId || "").trim();
+  const gameOpenIdText = String(gameOpenId || "").trim();
+  const segments = canonicalText ? canonicalText.split("-") : [];
+  const canonicalSuffix = segments.length > 1 ? segments.slice(1).join("-") : "";
+  const format = /^\d+-\d+$/.test(canonicalText)
+    ? "numeric-prefix-and-id"
+    : canonicalText.includes("-")
+      ? "hyphenated-other"
+      : canonicalText
+        ? "unprefixed-or-other"
+        : "missing";
+  const equality = canonicalText && gameOpenIdText
+    ? String(canonicalText === gameOpenIdText)
+    : "unavailable";
+  const suffixEquality = canonicalSuffix && gameOpenIdText
+    ? String(canonicalSuffix === gameOpenIdText)
+    : "unavailable";
+
+  return [
+    `canonicalIntlOpenId=${canonicalText ? "present" : "missing"}`,
+    `format=${format}`,
+    `segmentLengths=[${segments.map((segment) => segment.length).join(",")}]`,
+    `equalsGameOpenIdCookie=${equality}`,
+    `suffixEqualsGameOpenIdCookie=${suffixEquality}`,
+  ].join("; ");
+};
+
+/**
+ * 仅在 1300015 时执行有界恢复。
+ * 返回的成功响应可进入正式判定；所有标识日志均只输出结构和比较结果。
+ */
+const recoverPlayerInfoSystemError = async (onDiagnostic) => {
+  emitDiagnostic(
+    onDiagnostic,
+    `[恢复] 检测到 ${PLAYER_INFO_SYSTEM_ERROR_CODE}，开始有界重试: delays=[${PLAYER_INFO_RETRY_DELAYS_MS.join(",")}]ms`
+  );
+
+  for (let index = 0; index < PLAYER_INFO_RETRY_DELAYS_MS.length; index += 1) {
+    const attempt = index + 1;
+    const delayMs = PLAYER_INFO_RETRY_DELAYS_MS[index];
+    const label = `恢复重试${attempt}`;
+    emitDiagnostic(onDiagnostic, `[${label}] 等待 ${delayMs}ms`);
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+
+    let retryResponse = null;
+    try {
+      retryResponse = await postJson(
+        USER_GAME_PLAYER_INFO_URL,
+        {},
+        (message) => emitDiagnostic(onDiagnostic, `[${label}] ${message}`)
+      );
+    } catch (error) {
+      emitDiagnostic(
+        onDiagnostic,
+        `[${label}] 请求异常: ${sanitizeDiagnosticText(error?.message || error)}`
+      );
+    }
+
+    const retryCode = getApiBusinessCode(retryResponse);
+    const retryAreaId = retryResponse?.data?.area_id;
+    const retrySucceeded = isPlayerInfoResponseSuccessful(retryResponse);
+    emitDiagnostic(
+      onDiagnostic,
+      `[${label}] 结果: businessCode=${describeDiagnosticValue(retryCode)}; area_id=${describeDiagnosticValue(retryAreaId)}; success=${retrySucceeded}`
+    );
+
+    if (retrySucceeded) {
+      emitDiagnostic(
+        onDiagnostic,
+        `[恢复结论] 第 ${attempt} 次重试成功，正式判定将采用本次响应`
+      );
+      return { response: retryResponse, source: `retry-${attempt}` };
+    }
+
+    if (
+      retryResponse &&
+      String(retryCode) !== PLAYER_INFO_SYSTEM_ERROR_CODE
+    ) {
+      emitDiagnostic(
+        onDiagnostic,
+        `[${label}] 业务码已变为 ${describeDiagnosticValue(retryCode)}，停止空请求重试`
+      );
+      break;
+    }
+  }
+
+  emitDiagnostic(
+    onDiagnostic,
+    "[恢复] 空请求重试未成功，开始玩家标识后备链路"
+  );
+
+  let gameOpenId = "";
+  try {
+    gameOpenId = await getIntlOpenId();
+    emitDiagnostic(
+      onDiagnostic,
+      `[后备1-game_openid参数] game_openid Cookie: ${gameOpenId ? "present" : "empty"}`
+    );
+  } catch (error) {
+    emitDiagnostic(
+      onDiagnostic,
+      `[后备1-game_openid参数] 无法读取 game_openid Cookie: ${sanitizeDiagnosticText(error?.message || error)}`
+    );
+  }
+
+  let gameOpenIdResponse = null;
+  if (gameOpenId) {
+    try {
+      gameOpenIdResponse = await postJson(
+        USER_GAME_PLAYER_INFO_URL,
+        { intl_openid: gameOpenId },
+        (message) => emitDiagnostic(onDiagnostic, `[后备1-game_openid参数] ${message}`)
+      );
+    } catch (error) {
+      emitDiagnostic(
+        onDiagnostic,
+        `[后备1-game_openid参数] 请求异常: ${sanitizeDiagnosticText(error?.message || error)}`
+      );
+    }
+  } else {
+    emitDiagnostic(
+      onDiagnostic,
+      "[后备1-game_openid参数] 跳过请求: game_openid Cookie 不存在"
+    );
+  }
+
+  const gameOpenIdCode = getApiBusinessCode(gameOpenIdResponse);
+  const gameOpenIdAreaId = gameOpenIdResponse?.data?.area_id;
+  const gameOpenIdSucceeded = isPlayerInfoResponseSuccessful(gameOpenIdResponse);
+  emitDiagnostic(
+    onDiagnostic,
+    `[后备1-game_openid参数] 结果: businessCode=${describeDiagnosticValue(gameOpenIdCode)}; area_id=${describeDiagnosticValue(gameOpenIdAreaId)}; success=${gameOpenIdSucceeded}`
+  );
+
+  if (gameOpenIdSucceeded) {
+    emitDiagnostic(
+      onDiagnostic,
+      "[恢复结论] game_openid Cookie 参数请求成功，正式判定将采用本次响应"
+    );
+    return { response: gameOpenIdResponse, source: "game-openid-cookie" };
+  }
+
+  let checkLoginResponse = null;
+  try {
+    checkLoginResponse = await postJson(
+      USER_CHECK_LOGIN_URL,
+      {},
+      (message) => emitDiagnostic(onDiagnostic, `[后备2-CheckLogin] ${message}`)
+    );
+  } catch (error) {
+    emitDiagnostic(
+      onDiagnostic,
+      `[后备2-CheckLogin] 请求异常: ${sanitizeDiagnosticText(error?.message || error)}`
+    );
+  }
+
+  const checkLoginCode = getApiBusinessCode(checkLoginResponse);
+  const checkLoginSucceeded = isApiResponseSuccessful(checkLoginResponse);
+  emitDiagnostic(
+    onDiagnostic,
+    `[后备2-CheckLogin] 结果: businessCode=${describeDiagnosticValue(checkLoginCode)}; success=${checkLoginSucceeded}`
+  );
+
+  let userInfoResponse = null;
+  try {
+    userInfoResponse = await postJson(
+      USER_INFO_NEW_URL,
+      {},
+      (message) => emitDiagnostic(onDiagnostic, `[后备3-GetUserInfoNew] ${message}`)
+    );
+  } catch (error) {
+    emitDiagnostic(
+      onDiagnostic,
+      `[后备3-GetUserInfoNew] 请求异常: ${sanitizeDiagnosticText(error?.message || error)}`
+    );
+  }
+
+  const userInfoCode = getApiBusinessCode(userInfoResponse);
+  const canonicalIntlOpenId = getCanonicalIntlOpenId(userInfoResponse);
+  const userInfoSucceeded =
+    isApiResponseSuccessful(userInfoResponse) && Boolean(canonicalIntlOpenId);
+  emitDiagnostic(
+    onDiagnostic,
+    `[后备3-GetUserInfoNew] 结果: businessCode=${describeDiagnosticValue(userInfoCode)}; info=${userInfoResponse?.data?.info ? "present" : "missing"}; success=${userInfoSucceeded}`
+  );
+  emitDiagnostic(
+    onDiagnostic,
+    `[后备3-GetUserInfoNew] 标识关系: ${summarizeIntlOpenIdRelation(canonicalIntlOpenId, gameOpenId)}`
+  );
+
+  if (!canonicalIntlOpenId) {
+    emitDiagnostic(
+      onDiagnostic,
+      `[恢复结论] 官网用户信息链路未取得正式 intl_openid；CheckLogin=${checkLoginSucceeded}; GetUserInfoNew=${userInfoSucceeded}`
+    );
+    return null;
+  }
+
+  let privacyResponse = null;
+  try {
+    privacyResponse = await postJson(
+      USER_PRIVACY_SETTING_URL,
+      { intl_openid: canonicalIntlOpenId },
+      (message) => emitDiagnostic(onDiagnostic, `[后备4-正式intl_openid隐私] ${message}`)
+    );
+  } catch (error) {
+    emitDiagnostic(
+      onDiagnostic,
+      `[后备4-正式intl_openid隐私] 请求异常: ${sanitizeDiagnosticText(error?.message || error)}`
+    );
+  }
+
+  const privacyCode = getApiBusinessCode(privacyResponse);
+  const privacySucceeded = isApiResponseSuccessful(privacyResponse);
+  emitDiagnostic(
+    onDiagnostic,
+    `[后备4-正式intl_openid隐私] 结果: businessCode=${describeDiagnosticValue(privacyCode)}; success=${privacySucceeded}`
+  );
+
+  let canonicalPlayerInfoResponse = null;
+  try {
+    canonicalPlayerInfoResponse = await postJson(
+      USER_GAME_PLAYER_INFO_URL,
+      { intl_openid: canonicalIntlOpenId },
+      (message) => emitDiagnostic(onDiagnostic, `[后备5-正式intl_openid玩家] ${message}`)
+    );
+  } catch (error) {
+    emitDiagnostic(
+      onDiagnostic,
+      `[后备5-正式intl_openid玩家] 请求异常: ${sanitizeDiagnosticText(error?.message || error)}`
+    );
+  }
+
+  const canonicalPlayerInfoCode = getApiBusinessCode(canonicalPlayerInfoResponse);
+  const canonicalPlayerInfoAreaId = canonicalPlayerInfoResponse?.data?.area_id;
+  const canonicalPlayerInfoSucceeded =
+    isPlayerInfoResponseSuccessful(canonicalPlayerInfoResponse);
+  emitDiagnostic(
+    onDiagnostic,
+    `[后备5-正式intl_openid玩家] 结果: businessCode=${describeDiagnosticValue(canonicalPlayerInfoCode)}; area_id=${describeDiagnosticValue(canonicalPlayerInfoAreaId)}; success=${canonicalPlayerInfoSucceeded}`
+  );
+
+  if (canonicalPlayerInfoSucceeded) {
+    emitDiagnostic(
+      onDiagnostic,
+      `[恢复结论] 正式 intl_openid 玩家请求成功，正式判定将采用本次响应；privacy=${privacySucceeded}`
+    );
+    return {
+      response: canonicalPlayerInfoResponse,
+      source: "canonical-intl-openid",
+    };
+  }
+
+  emitDiagnostic(
+    onDiagnostic,
+    `[恢复结论] 所有恢复路径均未取得有效玩家信息；CheckLogin=${checkLoginSucceeded}; privacy=${privacySucceeded}; playerBusinessCode=${describeDiagnosticValue(canonicalPlayerInfoCode)}`
+  );
+  return null;
+};
+
+// 获取最新昵称（优先 BasicInfo.nickname，回退旧 role_name）；不因空昵称判定 Cookie 失效
+export const getRoleName = async (onDiagnostic) => {
+  emitDiagnostic(onDiagnostic, "getRoleName 开始");
+  const oldPromise = postJson(
+    USER_GAME_PLAYER_INFO_URL,
+    {},
+    onDiagnostic
+  ).catch(err => {
+    emitDiagnostic(
+      onDiagnostic,
+      `GetUserGamePlayerInfo 请求失败并回退为空结果: ${sanitizeDiagnosticText(err?.message || err)}`
+    );
+    return { error: err };
+  });
+
+  let oldResp = await oldPromise;
+  if (
+    !oldResp.error &&
+    String(getApiBusinessCode(oldResp)) === PLAYER_INFO_SYSTEM_ERROR_CODE
+  ) {
+    const recovery = await recoverPlayerInfoSystemError(onDiagnostic);
+    if (recovery?.response) {
+      oldResp = recovery.response;
+      emitDiagnostic(
+        onDiagnostic,
+        `[恢复] 正式判定已切换到恢复响应: source=${recovery.source}`
+      );
+    } else {
+      emitDiagnostic(
+        onDiagnostic,
+        "[恢复] 恢复未成功，正式判定继续使用首次原始响应"
+      );
+    }
+  }
+
   const areaId = (!oldResp.error && (oldResp?.data?.area_id)) ? oldResp.data.area_id : "";
   const oldName = !oldResp.error ? (oldResp?.data?.role_name || "") : "";
 
+  emitDiagnostic(
+    onDiagnostic,
+    `GetUserGamePlayerInfo 解析结果: area_id=${describeDiagnosticValue(areaId)}; role_name=${oldName ? "present" : "empty"}; requestError=${oldResp.error ? "yes" : "no"}`
+  );
 
   if (areaId) {
     let intlOpenId = "";
-    intlOpenId = await getIntlOpenId();
+    try {
+      intlOpenId = await getIntlOpenId();
+      emitDiagnostic(onDiagnostic, `game_openid Cookie: ${intlOpenId ? "present" : "empty"}`);
+    } catch (error) {
+      emitDiagnostic(
+        onDiagnostic,
+        `读取 game_openid Cookie 失败: ${sanitizeDiagnosticText(error?.message || error)}`
+      );
+      throw error;
+    }
     const payload = { nikke_area_id: parseInt(areaId) };
     if (intlOpenId) payload.intl_open_id = intlOpenId;
     const basicResp = await postJson(
       "https://api.blablalink.com/api/game/proxy/Game/GetUserProfileBasicInfo",
-      payload
-    ).catch(err => ({ error: err }));
+      payload,
+      onDiagnostic
+    ).catch(err => {
+      emitDiagnostic(
+        onDiagnostic,
+        `GetUserProfileBasicInfo 请求失败，保留旧接口结果: ${sanitizeDiagnosticText(err?.message || err)}`
+      );
+      return { error: err };
+    });
     if (!basicResp.error) {
       const info = basicResp?.data?.basic_info || {};
       const finalName = info.nickname || oldName || "";
+      const finalAreaId = info.area_id || areaId;
+      emitDiagnostic(
+        onDiagnostic,
+        `getRoleName 完成: source=basic-or-old; area_id=${describeDiagnosticValue(finalAreaId)}; role_name=${finalName ? "present" : "empty"}`
+      );
       return {
         role_name: finalName,
-        area_id: info.area_id || areaId
+        area_id: finalAreaId
       };
     }
   }
-  if (!oldResp.error) return { role_name: oldName || "", area_id: areaId };
+  if (!oldResp.error) {
+    emitDiagnostic(
+      onDiagnostic,
+      `getRoleName 完成: source=old; area_id=${describeDiagnosticValue(areaId)}; role_name=${oldName ? "present" : "empty"}`
+    );
+    return { role_name: oldName || "", area_id: areaId };
+  }
+  emitDiagnostic(onDiagnostic, "getRoleName 完成: source=request-error; area_id=empty-string; role_name=empty");
   return { role_name: "", area_id: areaId };
 };
 
@@ -432,29 +882,62 @@ const parseCookieValue = (cookieStr, name) => {
 };
 
 /**
- * 验证账号 Cookie 是否有效（并发模式）
+ * 验证账号 Cookie 登录态是否有效（并发模式）。
+ * 玩家信息接口不可用时使用 CheckLogin 区分“Cookie 失效”和“角色信息暂不可用”。
  * @param {{game_uid: string, cookie: string}} account - 账号对象
- * @returns {Promise<{valid: boolean, roleInfo?: {role_name: string, area_id: string}, error?: string}>}
+ * @returns {Promise<{
+ *   valid: boolean,
+ *   roleReady?: boolean,
+ *   roleInfo?: {role_name: string, area_id: string},
+ *   error?: string
+ * }>}
  */
-export const validateCookieWithAccount = async (account) => {
+export const validateCookieWithAccount = async (account, onDiagnostic) => {
+  const cookieNames = String(account.cookie || "")
+    .split(/;\s*/)
+    .map((entry) => entry.split("=")[0]?.trim())
+    .filter(Boolean);
+  emitDiagnostic(
+    onDiagnostic,
+    `保存Cookie检查: cookie=${account.cookie ? "present" : "empty"}; game_uid=${account.game_uid ? "present" : "empty"}; cookieCount=${cookieNames.length}; cookieNames=[${[...new Set(cookieNames)].sort().join(",")}]`
+  );
+
   if (!account.cookie) {
+    emitDiagnostic(onDiagnostic, "保存Cookie验证结束: invalid; reason=无 Cookie");
     return { valid: false, error: "无 Cookie" };
   }
-  
+
+  if (!account.game_uid) {
+    emitDiagnostic(onDiagnostic, "保存Cookie验证结束: invalid; reason=缺少 game_uid");
+    return { valid: false, error: "缺少 game_uid" };
+  }
+
+  let playerInfoResponse = null;
+  let playerInfoError = null;
   try {
-    const resp = await postJsonWithAccount(
-      "https://api.blablalink.com/api/ugc/direct/standalonesite/User/GetUserGamePlayerInfo",
+    playerInfoResponse = await postJsonWithAccount(
+      USER_GAME_PLAYER_INFO_URL,
       {},
-      account.game_uid
+      account.game_uid,
+      onDiagnostic
     );
-    
-    const areaId = resp?.data?.area_id;
-    const roleName = resp?.data?.role_name || "";
-    
-    if (!areaId) {
-      return { valid: false, error: "area_id 为空" };
-    }
-    
+  } catch (error) {
+    playerInfoError = error;
+    emitDiagnostic(
+      onDiagnostic,
+      `保存Cookie玩家信息请求异常，将使用 CheckLogin 判断登录态: ${sanitizeDiagnosticText(error?.message || error)}`
+    );
+  }
+
+  const areaId = playerInfoResponse?.data?.area_id;
+  const roleName = playerInfoResponse?.data?.role_name || "";
+  const playerInfoCode = getApiBusinessCode(playerInfoResponse);
+  emitDiagnostic(
+    onDiagnostic,
+    `保存Cookie玩家信息解析: businessCode=${describeDiagnosticValue(playerInfoCode)}; area_id=${describeDiagnosticValue(areaId)}; role_name=${roleName ? "present" : "empty"}`
+  );
+
+  if (areaId) {
     // 尝试获取更详细的信息
     const intlOpenId = parseCookieValue(account.cookie, "game_openid") || "";
     const payload = { nikke_area_id: parseInt(areaId) };
@@ -463,21 +946,86 @@ export const validateCookieWithAccount = async (account) => {
     const basicResp = await postJsonWithAccount(
       "https://api.blablalink.com/api/game/proxy/Game/GetUserProfileBasicInfo",
       payload,
-      account.game_uid
-    ).catch(() => null);
+      account.game_uid,
+      onDiagnostic
+    ).catch((error) => {
+      emitDiagnostic(
+        onDiagnostic,
+        `保存Cookie BasicInfo 请求失败但不影响有效性: ${sanitizeDiagnosticText(error?.message || error)}`
+      );
+      return null;
+    });
     
     const finalName = basicResp?.data?.basic_info?.nickname || roleName || "";
+    emitDiagnostic(
+      onDiagnostic,
+      `保存Cookie验证结束: valid; area_id=${describeDiagnosticValue(areaId)}; role_name=${finalName ? "present" : "empty"}`
+    );
     
     return {
       valid: true,
+      roleReady: true,
       roleInfo: {
         role_name: finalName,
         area_id: String(areaId)
       }
     };
-  } catch (error) {
-    return { valid: false, error: error.message };
   }
+
+  emitDiagnostic(
+    onDiagnostic,
+    "保存Cookie未取得 area_id，改用 CheckLogin 验证 Cookie 登录态"
+  );
+
+  let checkLoginResponse = null;
+  let checkLoginError = null;
+  try {
+    checkLoginResponse = await postJsonWithAccount(
+      USER_CHECK_LOGIN_URL,
+      {},
+      account.game_uid,
+      (message) => emitDiagnostic(onDiagnostic, `[登录态后备-CheckLogin] ${message}`)
+    );
+  } catch (error) {
+    checkLoginError = error;
+    emitDiagnostic(
+      onDiagnostic,
+      `[登录态后备-CheckLogin] 请求异常: ${sanitizeDiagnosticText(error?.message || error)}`
+    );
+  }
+
+  const checkLoginCode = getApiBusinessCode(checkLoginResponse);
+  const authenticated = isApiResponseSuccessful(checkLoginResponse);
+  emitDiagnostic(
+    onDiagnostic,
+    `[登录态后备-CheckLogin] 判定: businessCode=${describeDiagnosticValue(checkLoginCode)}; authenticated=${authenticated}`
+  );
+
+  if (authenticated) {
+    emitDiagnostic(
+      onDiagnostic,
+      `保存Cookie验证结束: authenticated; roleReady=false; playerBusinessCode=${describeDiagnosticValue(playerInfoCode)}`
+    );
+    return {
+      valid: true,
+      roleReady: false,
+      roleInfo: {
+        role_name: roleName,
+        area_id: ""
+      }
+    };
+  }
+
+  const errorMessage =
+    checkLoginError?.message ||
+    (checkLoginCode !== undefined && checkLoginCode !== null
+      ? `CheckLogin 失败 (${checkLoginCode})`
+      : playerInfoError?.message || "Cookie 登录态验证失败");
+  emitDiagnostic(
+    onDiagnostic,
+    `保存Cookie验证结束: invalid; reason=${sanitizeDiagnosticText(errorMessage)}`
+  );
+  return { valid: false, error: errorMessage };
 };
 
 /**


### PR DESCRIPTION
- 取得新的 game_token 即判定重登- 成功，立即保存 Cookie，不再由 area_id 决定登录成败。
- 保存 Cookie 验证遇到角色接口异常时，改用 CheckLogin 判断登录态。
- 本批次任一账号取得 area_id 后，会自动回填给其他已登录账号。
- “仅更新 Cookie”模式完全跳过 area_id 验证。
- 若意外检测到多个不同的 area_id，会停止共享回填，避免错误爬取。
- 如果整批账号都没能取得任何 area_id，Cookie 仍算更新成功，但本轮角色数据爬取会停止。

防止弱智su的后端出问题无法回传area_id导致爬取失败。
加了详细日志出问题好排查……